### PR TITLE
De-duplicate multiple copies from repeater

### DIFF
--- a/production_ready_server.py
+++ b/production_ready_server.py
@@ -3,7 +3,6 @@
 Production Conference Server (Separate Machine Only) - With Station Timeout
 Designed to run on a dedicated machine, separate from stations
 Added: Automatic timeout of inactive stations
-Added: IPv6 dual-stack support with automatic fallback to IPv4
 """
 
 import socket
@@ -23,10 +22,9 @@ except ImportError:
     print("⚠️  Using hex fallback for station IDs")
 
 class ProductionConferenceServer:
-    """Production conference server for separate machine deployment with station timeout and IPv6 support"""
-
+    """Production conference server for separate machine deployment with station timeout"""
     
-    def __init__(self, listen_port=57372, station_timeout=3600):
+    def __init__(self, listen_port=57372, station_timeout=300):
         self.listen_port = listen_port
         self.station_timeout = station_timeout  # Station inactivity timeout in seconds
         self.socket = None
@@ -41,11 +39,8 @@ class ProductionConferenceServer:
             'frames_forwarded': 0,
             'unique_stations': 0,
             'decode_errors': 0,
-
             'timed_out_stations': 0,
-            'start_time': time.time(),
-            'ipv4_connections': 0,
-            'ipv6_connections': 0
+            'start_time': time.time()
         }
         
         # Setup signal handlers for clean shutdown
@@ -57,69 +52,23 @@ class ProductionConferenceServer:
         print(f"\n🛑 Received signal {signum}, shutting down...")
         self.running = False
         
-    def _create_socket(self):
-        """Create socket with dual-stack IPv6 support, fallback to IPv4"""
-        try:
-            # Try IPv6 dual-stack first (preferred)
-            try:
-                sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                # Enable dual-stack (IPv4 + IPv6) - this is usually default on Linux
-                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-                sock.bind(('::', self.listen_port))
-                print("🌍 IPv6 dual-stack socket created (supports both IPv4 and IPv6)")
-                return sock, "dual-stack"
-            except Exception as e:
-                print(f"⚠️  IPv6 dual-stack failed: {e}")
-                print("📡 Falling back to IPv4-only...")
-            
-            # Fallback to IPv4-only
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(('0.0.0.0', self.listen_port))
-            print("📡 IPv4-only socket created")
-            return sock, "ipv4-only"
-            
-        except Exception as e:
-            raise Exception(f"Failed to create socket: {e}")
-    
-    def _normalize_address(self, addr):
-        """Normalize address for IPv4-mapped IPv6 addresses"""
-        ip, port = addr[:2]  # Handle both IPv4 (ip, port) and IPv6 (ip, port, flow, scope)
-        
-        # Convert IPv4-mapped IPv6 addresses back to IPv4 format for consistency
-        if ip.startswith('::ffff:') and '.' in ip:
-            ipv4_part = ip.split('::ffff:')[1]
-            return ipv4_part, port
-        
-        return ip, port
-    
-    def _is_ipv6_address(self, ip):
-        """Check if address is IPv6"""
-        return ':' in ip and not ip.startswith('::ffff:')
-        
     def start(self):
         """Start the production conference server"""
         try:
-            self.socket, socket_type = self._create_socket()
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.socket.bind(('0.0.0.0', self.listen_port))
             self.socket.settimeout(1.0)  # Allow periodic checking
             self.running = True
             
             print("=" * 80)
             print("📡 OPULENT VOICE CONFERENCE SERVER")
             print("=" * 80)
-            print(f"📡 Listening on: {socket_type} port {self.listen_port}")
+            print(f"📡 Listening on: 0.0.0.0:{self.listen_port}")
             print(f"🏷️  Station decoding: {'✅ Base-40 callsigns' if PROPER_DECODER_AVAILABLE else '⚠️  Hex IDs'}")
             print(f"🌍 Mode: Production (separate machine)")
             print(f"🎯 Forward strategy: IP-based routing to port {self.listen_port}")
             print(f"⏰ Station timeout: {self.station_timeout} seconds ({self.station_timeout/60:.1f} minutes)")
-
-            if socket_type == "dual-stack":
-                print("🌐 IPv4 clients: python3 interlocutor.py CALL -i <server_ipv4>")
-                print("🌐 IPv6 clients: python3 interlocutor.py CALL -i <server_ipv6>")
-            else:
-                print("🌐 IPv4 clients: python3 interlocutor.py CALL -i <server_ip>")
-
             print("=" * 80)
             print("🚀 Server ready for connections")
             print("📊 Statistics will be shown every 60 seconds")
@@ -135,13 +84,6 @@ class ProductionConferenceServer:
                     frame_data, sender_addr = self.socket.recvfrom(4096)
                     frame_count += 1
                     self.stats['frames_received'] += 1
-                    
-                    # Track connection types
-                    normalized_ip, _ = self._normalize_address(sender_addr)
-                    if self._is_ipv6_address(normalized_ip):
-                        self.stats['ipv6_connections'] += 1
-                    else:
-                        self.stats['ipv4_connections'] += 1
                     
                     # Process frame
                     self._process_frame(frame_data, sender_addr)
@@ -172,7 +114,7 @@ class ProductionConferenceServer:
             
     def _process_frame(self, frame_data, sender_addr):
         """Process incoming frame and forward to other stations"""
-        sender_ip, sender_port = self._normalize_address(sender_addr)
+        sender_ip, sender_port = sender_addr[:2]  # Extract IP and port
         
         # Extract and validate callsign
         callsign = self._extract_callsign(frame_data)
@@ -180,11 +122,11 @@ class ProductionConferenceServer:
             self.stats['decode_errors'] += 1
             return
         
-        # Update station registry
-        self._update_station(callsign, sender_ip)
+        # Update station registry with full endpoint info
+        self._update_station(callsign, sender_addr)
         
         # Forward to all other stations
-        forwarded = self._forward_frame(frame_data, callsign, sender_ip)
+        forwarded = self._forward_frame(frame_data, callsign, sender_addr)
         self.stats['frames_forwarded'] += forwarded
         
     def _extract_callsign(self, frame_data):
@@ -214,8 +156,9 @@ class ProductionConferenceServer:
         except Exception:
             return None
     
-    def _update_station(self, callsign, sender_ip):
-        """Update station registry"""
+    def _update_station(self, callsign, sender_addr):
+        """Update station registry with IP:port tracking"""
+        sender_ip, sender_port = sender_addr[:2]  # Extract IP and port
         current_time = time.time()
         
         if callsign in self.stations:
@@ -224,50 +167,71 @@ class ProductionConferenceServer:
             station_info['last_seen'] = current_time
             station_info['frame_count'] += 1
             
-            # Check for IP changes
-            if station_info['ip'] != sender_ip:
-                ip_type = "IPv6" if self._is_ipv6_address(sender_ip) else "IPv4"
-                old_type = "IPv6" if self._is_ipv6_address(station_info['ip']) else "IPv4"
-                print(f"📍 {callsign}: {old_type} {station_info['ip']} → {ip_type} {sender_ip}")
+            # Check for endpoint changes (IP or port)
+            old_endpoint = f"{station_info['ip']}:{station_info['port']}"
+            new_endpoint = f"{sender_ip}:{sender_port}"
+            
+            if old_endpoint != new_endpoint:
+                print(f"📍 {callsign}: endpoint changed {old_endpoint} → {new_endpoint}")
                 station_info['ip'] = sender_ip
+                station_info['port'] = sender_port
         else:
             # New station
-            ip_type = "IPv6" if self._is_ipv6_address(sender_ip) else "IPv4"
-            print(f"🆕 NEW STATION: {callsign} at {sender_ip} ({ip_type})")
+            print(f"🆕 NEW STATION: {callsign} at {sender_ip}:{sender_port}")
             self.stations[callsign] = {
                 'ip': sender_ip,
+                'port': sender_port,
                 'last_seen': current_time,
                 'frame_count': 1
             }
             self.stats['unique_stations'] += 1
     
-    def _forward_frame(self, frame_data, sender_callsign, sender_ip):
-        """Forward frame to all other stations"""
+    def _forward_frame(self, frame_data, sender_callsign, sender_addr):
+        """Forward frame with IP deduplication to eliminate duplicate packets"""
+        sender_ip, sender_port = sender_addr[:2]
+        sender_endpoint = f"{sender_ip}:{sender_port}"
+        
         forwarded_count = 0
-        failed_stations = []
+        failed_ips = set()
+        
+        # Collect unique target IPs (deduplication happens here)
+        unique_target_ips = set()
         
         for callsign, info in self.stations.items():
             if callsign != sender_callsign:
-                target_ip = info['ip']
+                station_endpoint = f"{info['ip']}:{info['port']}"
                 
-                # Convert IPv4 addresses to IPv4-mapped IPv6 format for dual-stack socket
-                if not self._is_ipv6_address(target_ip) and '::ffff:' not in target_ip:
-                    target_ip = f"::ffff:{target_ip}"
+                # Skip if same endpoint as sender (avoid echo)
+                if station_endpoint == sender_endpoint:
+                    continue
                 
-                target_addr = (target_ip, self.listen_port)
-                
-                try:
-                    self.socket.sendto(frame_data, target_addr)
-                    forwarded_count += 1
-                    
-                except Exception as e:
-                    print(f"❌ Forward failed to {callsign} at {info['ip']}: {e}")
-                    failed_stations.append(callsign)
+                # Add target IP to set (automatically deduplicates by IP)
+                unique_target_ips.add(info['ip'])
         
-        # Remove failed stations
-        for callsign in failed_stations:
-            print(f"🗑️  Removing unreachable station: {callsign}")
-            del self.stations[callsign]
+        # Send one packet per unique IP address
+        for target_ip in unique_target_ips:
+            target_addr = (target_ip, self.listen_port)
+            
+            try:
+                self.socket.sendto(frame_data, target_addr)
+                forwarded_count += 1
+                
+            except Exception as e:
+                print(f"❌ Forward failed to {target_ip}: {e}")
+                failed_ips.add(target_ip)
+        
+        # Remove stations at failed IPs
+        if failed_ips:
+            failed_stations = []
+            for callsign, info in self.stations.items():
+                if info['ip'] in failed_ips:
+                    failed_stations.append(callsign)
+            
+            for callsign in failed_stations:
+                station_info = self.stations[callsign]
+                endpoint = f"{station_info['ip']}:{station_info['port']}"
+                print(f"🗑️  Removing unreachable station: {callsign} at {endpoint}")
+                del self.stations[callsign]
         
         return forwarded_count
     
@@ -284,7 +248,8 @@ class ProductionConferenceServer:
         # Remove inactive stations
         for callsign, duration in inactive_stations:
             station_info = self.stations[callsign]
-            print(f"⏰ TIMEOUT: {callsign} at {station_info['ip']} - inactive for {duration/60:.1f} minutes")
+            endpoint = f"{station_info['ip']}:{station_info['port']}"
+            print(f"⏰ TIMEOUT: {callsign} at {endpoint} - inactive for {duration/60:.1f} minutes")
             del self.stations[callsign]
             self.stats['timed_out_stations'] += 1
     
@@ -301,9 +266,6 @@ class ProductionConferenceServer:
         print(f"👥 Active stations: {len(self.stations)}")
         print(f"❌ Decode errors: {self.stats['decode_errors']}")
         print(f"⏰ Timed out stations: {self.stats['timed_out_stations']}")
-        print(f"🌐 IPv4 connections: {self.stats['ipv4_connections']}")
-        print(f"🌐 IPv6 connections: {self.stats['ipv6_connections']}")
-
         
         if self.stats['frames_received'] > 0:
             efficiency = (self.stats['frames_forwarded'] / self.stats['frames_received']) * 100
@@ -311,12 +273,12 @@ class ProductionConferenceServer:
         
         if len(self.stations) > 0:
             print(f"\n📋 Active Stations:")
+            current_time = time.time()
             for callsign, info in self.stations.items():
-                age = time.time() - info['last_seen']
+                age = current_time - info['last_seen']
                 timeout_remaining = self.station_timeout - age
-                ip_type = "IPv6" if self._is_ipv6_address(info['ip']) else "IPv4"
-                print(f"   📡 {callsign} at {info['ip']} ({ip_type}, {info['frame_count']} frames, {age:.0f}s ago, timeout in {timeout_remaining/60:.1f}m)")
-
+                endpoint = f"{info['ip']}:{info['port']}"
+                print(f"   📡 {callsign} at {endpoint} ({info['frame_count']} frames, {age:.0f}s ago, timeout in {timeout_remaining/60:.1f}m)")
         
         print("=" * 60)
         
@@ -347,9 +309,6 @@ class ProductionConferenceServer:
         print(f"📤 Total forwarded: {self.stats['frames_forwarded']}")
         print(f"👥 Peak stations: {self.stats['unique_stations']}")
         print(f"⏰ Timed out stations: {self.stats['timed_out_stations']}")
-        print(f"🌐 IPv4 connections: {self.stats['ipv4_connections']}")
-        print(f"🌐 IPv6 connections: {self.stats['ipv6_connections']}")
-
         
         if self.stats['frames_received'] > 0:
             avg_rate = self.stats['frames_received'] / uptime
@@ -360,32 +319,30 @@ class ProductionConferenceServer:
 def create_argument_parser():
     """Create command line argument parser"""
     parser = argparse.ArgumentParser(
-        description='Production Opulent Voice Conference Server with IPv6 Support and Station Timeout',
+        description='Production Opulent Voice Conference Server with Station Timeout',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-    IPv6 SUPPORT:
-      • Server automatically creates dual-stack socket (IPv4 + IPv6)
-      • Automatic fallback to IPv4-only if IPv6 unavailable
-      • IPv4 clients connect normally: python3 interlocutor.py CALL -i <ipv4_addr>
-      • IPv6 clients use IPv6 address: python3 interlocutor.py CALL -i <ipv6_addr>
-      • Mixed networks with both IPv4 and IPv6 clients supported
-
-    STATION TIMEOUT FEATURE:
-      • Automatically removes stations that stop transmitting
-      • Default timeout: 5 minutes (300 seconds)
-      • Cleanup check runs every 30 seconds
-      • Prevents station registry from growing indefinitely
+STATION TIMEOUT FEATURE:
+  • Automatically removes stations that stop transmitting
+  • Default timeout: 5 minutes (300 seconds)
+  • Cleanup check runs every 30 seconds
+  • Prevents station registry from growing indefinitely
   
-    DEPLOYMENT REQUIREMENTS:
-      • Must run on a separate machine from interlocutor.py stations
-      • All stations use default port 57372 for clean routing
-      • Firewall must allow port 57372 for both IPv4 and IPv6
+DEPLOYMENT REQUIREMENTS:
+  • Must run on a separate machine from interlocutor.py stations
+  • Stations connect using: python3 interlocutor.py CALL -i <SERVER_IP>
+  • All stations use default port 57372 for clean routing
   
-    EXAMPLES:
-      %(prog)s                    # Listen dual-stack on port 57372, 5-minute timeout
-      %(prog)s -p 8000           # Listen dual-stack on port 8000
-      %(prog)s -t 600            # 10-minute station timeout
-      %(prog)s -v                # Enable verbose logging
+EXAMPLES:
+  %(prog)s                    # Listen on port 57372, 5-minute timeout
+  %(prog)s -t 600            # 10-minute station timeout
+  %(prog)s -p 8000 -t 180    # Port 8000, 3-minute timeout
+  %(prog)s -v                # Enable verbose logging
+  
+NETWORK SETUP:
+  • Ensure port 57372 (or custom port) is open in firewall
+  • Server listens on all interfaces (0.0.0.0)
+  • Stations automatically discovered by first transmission
         """
     )
     
@@ -399,8 +356,8 @@ def create_argument_parser():
     parser.add_argument(
         '-t', '--timeout',
         type=int,
-        default=3600,
-        help='Station inactivity timeout in seconds (default: 3600 = 60 minutes)'
+        default=300,
+        help='Station inactivity timeout in seconds (default: 300 = 5 minutes)'
     )
     
     parser.add_argument(
@@ -423,7 +380,7 @@ def main():
     args = parser.parse_args()
     
     print("📡 Production Opulent Voice Conference Server")
-    print(f"📡 Version: IPv6 Dual-Stack Support with Station Timeout")
+    print(f"📡 Version: IPv4 with Station Timeout")
     print(f"📡 Listen port: {args.port}")
     print(f"📡 Station timeout: {args.timeout} seconds ({args.timeout/60:.1f} minutes)")
     
@@ -447,7 +404,6 @@ def main():
     print(f"\n🚀 Starting server...")
     print(f"🌍 Stations should connect with: python3 interlocutor.py CALL -i <THIS_IP>")
     print(f"⏰ Inactive stations will timeout after {args.timeout/60:.1f} minutes")
-    print(f"🌐 Will try IPv6 dual-stack, fallback to IPv4 if needed")
     
     # Create and start server
     server = ProductionConferenceServer(args.port, args.timeout)


### PR DESCRIPTION
We are smarter about what we send. 

We keep track of active stations. For example: 
ANDY at 70.95.81.97:54321 (5 frames, 30s ago, timeout in 4.5m)
ANN at 70.95.81.97:54322 (3 frames, 45s ago, timeout in 4.2m)  
BOB at 70.95.76.225:54323 (8 frames, 10s ago, timeout in 4.8m)

BOB transmits and the Server sends 1 packet to 70.95.81.97. 
We are keeping track of the fact that two stations are at the same IP address. So we send one frame to that IP address to "cover" any stations that happen to be there. 
Both ANDY & ANN receive it (depending on the NAT/LAN - there are situations where it might not be forwarded to everyone, but in general this is how UDP works). 